### PR TITLE
Fix renv cache

### DIFF
--- a/.github/workflows/check-templates.yml
+++ b/.github/workflows/check-templates.yml
@@ -95,7 +95,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: |
-            ~/.local/share/renv
+            ~/.cache/R/renv
             ~/.staged.dependencies
           key: ${{ runner.os }}-renv-${{ hashFiles('**/renv.lock') }}
           restore-keys: ${{ runner.os }}-renv-

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -79,7 +79,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: |
-            ~/.local/share/renv
+            ~/.cache/R/renv
             ~/.staged.dependencies
           key: ${{ runner.os }}-renv-${{ hashFiles('**/renv.lock') }}
           restore-keys: ${{ runner.os }}-renv-

--- a/.github/workflows/lintr.yml
+++ b/.github/workflows/lintr.yml
@@ -77,7 +77,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: |
-            ~/.local/share/renv
+            ~/.cache/R/renv
             ~/.staged.dependencies
           key: ${{ runner.os }}-renv-${{ hashFiles('**/renv.lock') }}
           restore-keys: ${{ runner.os }}-renv-

--- a/.github/workflows/man-pages.yml
+++ b/.github/workflows/man-pages.yml
@@ -72,7 +72,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: |
-            ~/.local/share/renv
+            ~/.cache/R/renv
             ~/.staged.dependencies
           key: ${{ runner.os }}-renv-${{ hashFiles('**/renv.lock') }}
           restore-keys: ${{ runner.os }}-renv-

--- a/.github/workflows/pkgdown.yml
+++ b/.github/workflows/pkgdown.yml
@@ -98,7 +98,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: |
-            ~/.local/share/renv
+            ~/.cache/R/renv
             ~/.staged.dependencies
           key: ${{ runner.os }}-renv-${{ hashFiles('**/renv.lock') }}
           restore-keys: ${{ runner.os }}-renv-

--- a/.github/workflows/r-pkg-validation.yml
+++ b/.github/workflows/r-pkg-validation.yml
@@ -64,7 +64,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: |
-            ~/.local/share/renv
+            ~/.cache/R/renv
             ~/.staged.dependencies
           key: ${{ runner.os }}-renv-${{ hashFiles('**/renv.lock') }}
           restore-keys: ${{ runner.os }}-renv-

--- a/.github/workflows/readme-render.yml
+++ b/.github/workflows/readme-render.yml
@@ -69,7 +69,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: |
-            ~/.local/share/renv
+            ~/.cache/R/renv
             ~/.staged.dependencies
           key: ${{ runner.os }}-renv-${{ hashFiles('**/renv.lock') }}
           restore-keys: ${{ runner.os }}-renv-

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -74,7 +74,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: |
-            ~/.local/share/renv
+            ~/.cache/R/renv
             ~/.staged.dependencies
           key: ${{ runner.os }}-renv-${{ hashFiles('**/renv.lock') }}
           restore-keys: ${{ runner.os }}-renv-

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -72,7 +72,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: |
-            ~/.local/share/renv
+            ~/.cache/R/renv
             ~/.staged.dependencies
           key: ${{ runner.os }}-renv-${{ hashFiles('**/renv.lock') }}
           restore-keys: ${{ runner.os }}-renv-


### PR DESCRIPTION
Fix renv cache location. The old location is still on the frontend page of renv docs, so it's misleading. https://rstudio.github.io/renv/reference/paths.html